### PR TITLE
회원가입 + security 완료

### DIFF
--- a/src/main/java/apptive/backend/config/MemberConfig.java
+++ b/src/main/java/apptive/backend/config/MemberConfig.java
@@ -1,5 +1,7 @@
 package apptive.backend.config;
 
+import apptive.backend.handler.login.CustomLoginFailureHandler;
+import apptive.backend.handler.login.CustomLoginSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +14,9 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @RequiredArgsConstructor
 @Configuration
@@ -40,12 +45,61 @@ public class MemberConfig {
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers("/login/join/1", "/login/join/2");
+        return (web) -> web.ignoring().requestMatchers("/member/join/1", "/member/join/2");
+    }
+
+    @Bean
+    protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
+
+        //접근 권한
+        http.authorizeHttpRequests()
+                .requestMatchers("/", "/member/join/1", "/member/join/2", "/login").permitAll()
+                .anyRequest().authenticated();
+
+        //폼 로그인
+        http.formLogin()
+                .loginPage("/login")
+                .loginProcessingUrl("/login")
+                .failureHandler(failureHandler())
+                .successHandler(successHandler())
+                .permitAll()
+                .and()
+                .csrf().disable();
+
+        //로그아웃
+        http.logout()
+                .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
+                .logoutSuccessUrl("/login")
+                .invalidateHttpSession(true)
+                .clearAuthentication(true)
+                .deleteCookies("SESSION", "JSESSIONID");
+
+        //중복 로그인
+        http.sessionManagement()
+                .invalidSessionUrl("/login?invalidSession")
+                .sessionAuthenticationErrorUrl("/login?maximumSessions")
+                .maximumSessions(1) // 최대 허용 세션 수
+                .maxSessionsPreventsLogin(false) // 중복 로그인하면 기존 세션 만료
+                .expiredUrl("/login?expiredSession");
+
+        return http.build();
     }
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)  throws Exception{
         return authenticationConfiguration.getAuthenticationManager();
+    }
 
+    @Bean
+    public SimpleUrlAuthenticationSuccessHandler successHandler() {
+        SimpleUrlAuthenticationSuccessHandler successHandler = new CustomLoginSuccessHandler();
+        successHandler.setDefaultTargetUrl("/");
+
+        return successHandler;
+    }
+
+    @Bean
+    public AuthenticationFailureHandler failureHandler() {
+        return new CustomLoginFailureHandler();
     }
 }

--- a/src/main/java/apptive/backend/exception/ApiExceptionAdvice.java
+++ b/src/main/java/apptive/backend/exception/ApiExceptionAdvice.java
@@ -26,9 +26,9 @@ public class ApiExceptionAdvice {
     public ResponseEntity<ExceptionEntity> exceptionHandler(HttpServletRequest request, final PwdConditionException e) {
         e.printStackTrace();
         return ResponseEntity
-                .status(ExceptionEnum.PWD_CONDITION_EXCEPTION.getStatus())
+                .status(ExceptionEnum.PWD_NOT_SAME_EXCEPTION.getStatus())
                 .body(ExceptionEntity.builder()
-                        .errorCode(ExceptionEnum.PWD_CONDITION_EXCEPTION.getCode())
+                        .errorCode(ExceptionEnum.PWD_NOT_SAME_EXCEPTION.getCode())
                         .errorMessage(e.getMessage())
                         .build());
     }

--- a/src/main/java/apptive/backend/exception/ExceptionEnum.java
+++ b/src/main/java/apptive/backend/exception/ExceptionEnum.java
@@ -10,8 +10,11 @@ public enum ExceptionEnum {
 
     RUNTIME_EXCEPTION(HttpStatus.BAD_REQUEST, "E0001"),
     //로그인 관련 에러
-    PWD_CONDITION_EXCEPTION(HttpStatus.BAD_REQUEST, "E0002", "비밀번호가 같지 않습니다."),
-    SAME_MEMBER_NAME_EXCEPTION(HttpStatus.BAD_REQUEST, "E0003", "같은 닉네임이 존재합니다.");
+    PWD_NOT_SAME_EXCEPTION(HttpStatus.BAD_REQUEST, "E0002", "비밀번호가 같지 않습니다."),
+    PWD_CONDITION_EXCEPTION(HttpStatus.BAD_REQUEST, "E0002", "8자 이상 20자 이하의 숫자, 영문자, 특수문자를 포함한 비밀번호를 입력해주세요"),
+    SAME_MEMBER_NAME_EXCEPTION(HttpStatus.BAD_REQUEST, "E0003", "같은 닉네임이 존재합니다."),
+    MEMBER_NOT_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, "E0004", "존재하지 않는 회원입니다."),
+    WRONG_PWD_EXCEPTION(HttpStatus.BAD_REQUEST, "E0005", "비밀번호가 틀렸습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/apptive/backend/exception/login/MemberNotExistException.java
+++ b/src/main/java/apptive/backend/exception/login/MemberNotExistException.java
@@ -1,0 +1,15 @@
+package apptive.backend.exception.login;
+
+import apptive.backend.exception.ExceptionEnum;
+import lombok.Getter;
+
+@Getter
+public class MemberNotExistException extends RuntimeException{
+
+    private final ExceptionEnum error;
+
+    public MemberNotExistException(ExceptionEnum e) {
+        super(e.getMessage());
+        this.error = e;
+    }
+}

--- a/src/main/java/apptive/backend/handler/login/CustomLoginFailureHandler.java
+++ b/src/main/java/apptive/backend/handler/login/CustomLoginFailureHandler.java
@@ -1,0 +1,32 @@
+package apptive.backend.handler.login;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class CustomLoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+
+        String errorMsg = "";
+
+        if(exception instanceof BadCredentialsException) {
+          //비밀번호 입력 오류, ID 입력 오류
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("/login?error");
+
+        if(!errorMsg.equals("")) {
+            sb.append("=").append(errorMsg);
+        }
+
+        response.sendRedirect(sb.toString());
+    }
+}

--- a/src/main/java/apptive/backend/handler/login/CustomLoginSuccessHandler.java
+++ b/src/main/java/apptive/backend/handler/login/CustomLoginSuccessHandler.java
@@ -1,0 +1,20 @@
+package apptive.backend.handler.login;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+public class CustomLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws ServletException, IOException {
+
+        super.onAuthenticationSuccess(request, response, authentication);
+    }
+}

--- a/src/main/java/apptive/backend/login/controller/MemberController.java
+++ b/src/main/java/apptive/backend/login/controller/MemberController.java
@@ -1,23 +1,20 @@
 package apptive.backend.login.controller;
 
-import apptive.backend.exception.ExceptionEnum;
-import apptive.backend.exception.login.LoginException;
 import apptive.backend.login.dto.request.MemberRequestDto;
 import apptive.backend.login.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/login")
+@RequestMapping("/member")
 public class MemberController {
 
     private final MemberService memberService;
@@ -38,5 +35,19 @@ public class MemberController {
         Long memberId = memberService.createMember(memberDetail);
 
         return new ResponseEntity(memberId, HttpStatus.CREATED);
+    }
+
+    // <-------------------- DELETE part -------------------->
+    @DeleteMapping("/delete")
+    public ResponseEntity deleteMember(@RequestPart(name = "memberId")Long memberId,
+                                       HttpServletRequest httpServletRequest) {
+
+        memberService.deleteMember(memberId);
+
+        //저장된 세션 삭제
+        HttpSession session = httpServletRequest.getSession();
+        session.invalidate();
+
+        return new ResponseEntity("회원탈퇴가 완료되었습니다.", HttpStatus.OK);
     }
 }

--- a/src/main/java/apptive/backend/login/domain/Member.java
+++ b/src/main/java/apptive/backend/login/domain/Member.java
@@ -2,19 +2,18 @@ package apptive.backend.login.domain;
 
 import apptive.backend.config.StringListConverter;
 import apptive.backend.login.dto.request.MemberRequestDto;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import java.time.LocalDate;
+import java.io.Serializable;
 import java.util.List;
 
 @Entity
 @NoArgsConstructor
-public class Member {
+public class Member implements Serializable {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "memberId")
@@ -28,8 +27,8 @@ public class Member {
 
     // 멤버 닉네임과 비밀번호를 통해 로그인
     @Column(nullable = false)
-    private String memberNickName;
-    @Column(nullable = false)
+    private String memberNickname;
+    @Column(nullable = false) @Getter
     private String pwd;
 
     // 질병 추가 리스트 + nullable = true
@@ -41,8 +40,8 @@ public class Member {
     @Builder
     public Member(MemberRequestDto.PostMemberDetail memberDetail) {
 
-        this.memberNickName = memberDetail.getMemberNickname();
-        this.pwd = memberDetail.getPwd1();
+        this.memberNickname = memberDetail.getMemberNickname();
+        this.pwd = new BCryptPasswordEncoder().encode(memberDetail.getPwd1());
         this.memberAge = memberDetail.getMemberAge();
         this.memberSex = memberDetail.getMemberSex();
         this.diseaseList = memberDetail.getDiseaseList();

--- a/src/main/java/apptive/backend/login/dto/response/MemberResponseDto.java
+++ b/src/main/java/apptive/backend/login/dto/response/MemberResponseDto.java
@@ -1,11 +1,4 @@
 package apptive.backend.login.dto.response;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.stereotype.Service;
-
-import java.time.LocalDate;
-import java.util.List;
-
 public class MemberResponseDto {
 }

--- a/src/main/java/apptive/backend/login/provider/CustomAuthenticationProvider.java
+++ b/src/main/java/apptive/backend/login/provider/CustomAuthenticationProvider.java
@@ -1,0 +1,63 @@
+package apptive.backend.login.provider;
+
+import apptive.backend.login.domain.Member;
+import apptive.backend.login.service.LoginService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceAware;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.security.authentication.AccountStatusUserDetailsChecker;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsChecker;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider, MessageSourceAware {
+
+    private MessageSourceAware messages;
+
+    @Autowired
+    private LoginService loginService;
+
+    private final UserDetailsChecker userDetailsChecker = new AccountStatusUserDetailsChecker();
+
+    @Override
+    public void setMessageSource(MessageSource messageSource) {
+        this.messages = (MessageSourceAware) new MessageSourceAccessor(messageSource);
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String username = (String) authentication.getPrincipal();
+        String password = (String) authentication.getCredentials();
+
+        //비밀번호 확인
+        Member member = loginService.authenticate(username, password);
+
+        //예외 발생 여부 확인
+        preAuthenticationChecks(member);
+
+        return new UsernamePasswordAuthenticationToken(username, password, authentication.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    public void preAuthenticationChecks(Member memberDetail) {
+        try {
+            userDetailsChecker.check((UserDetails) memberDetail);
+        } catch (UsernameNotFoundException e) {
+            log.info("계정 없음");
+            throw e;
+        }
+    }
+}

--- a/src/main/java/apptive/backend/login/repository/MemberRepository.java
+++ b/src/main/java/apptive/backend/login/repository/MemberRepository.java
@@ -4,9 +4,9 @@ import apptive.backend.login.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    List<Long> findAllByMemberNickName(String memberNickname);
+    Optional<Member> findByMemberNickname(String memberNickname);
 }

--- a/src/main/java/apptive/backend/login/service/LoginService.java
+++ b/src/main/java/apptive/backend/login/service/LoginService.java
@@ -1,0 +1,54 @@
+package apptive.backend.login.service;
+
+import apptive.backend.exception.ExceptionEnum;
+import apptive.backend.exception.login.LoginException;
+import apptive.backend.exception.login.MemberNotExistException;
+import apptive.backend.login.domain.Member;
+import apptive.backend.login.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // <-------------------- ? -------------------->
+    public Member loadMemberByNickname(String memberNickname) throws MemberNotExistException {
+
+        Optional<Member> member = memberRepository.findByMemberNickname(memberNickname);
+        if(member.isEmpty()) {
+
+            throw new MemberNotExistException(ExceptionEnum.MEMBER_NOT_EXIST_EXCEPTION);
+        }
+
+        return member.get();
+    }
+
+    // <-------------------- auth part -------------------->
+    public Member authenticate(String memberNickname, String password) {
+
+        Optional<Member> optionalMember = memberRepository.findByMemberNickname(memberNickname);
+
+        if(optionalMember.isPresent()) {
+
+            Member member = optionalMember.get();
+            if(passwordEncoder.matches(password, member.getPwd())) {
+
+            } else {
+                throw new LoginException(ExceptionEnum.WRONG_PWD_EXCEPTION);
+            }
+        } else {
+            throw new MemberNotExistException(ExceptionEnum.MEMBER_NOT_EXIST_EXCEPTION);
+        }
+
+        return optionalMember.get();
+    }
+}

--- a/src/main/java/apptive/backend/validation/login/PasswordValidator.java
+++ b/src/main/java/apptive/backend/validation/login/PasswordValidator.java
@@ -1,5 +1,7 @@
 package apptive.backend.validation.login;
 
+import apptive.backend.exception.ExceptionEnum;
+import apptive.backend.exception.login.PwdConditionException;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.springframework.stereotype.Component;
@@ -25,12 +27,14 @@ public class PasswordValidator implements ConstraintValidator<Password, String> 
 
         if(!isValidPassword) {
 
-            context.disableDefaultConstraintViolation();;
+            context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(
-                    MessageFormat.format("{0}자 이상 {1}자 이하의 숫자, 영문자, 특수문자를 포함한 비밀번호를 입력해주세요.", MIN_SIZE, MAX_SIZE))
+                            MessageFormat.format("{0}자 이상 {1}자 이하의 숫자, 영문자, 특수문자를 포함한 비밀번호를 입력해주세요.", MIN_SIZE, MAX_SIZE))
                     .addConstraintViolation();
+
+            throw new PwdConditionException(ExceptionEnum.PWD_CONDITION_EXCEPTION);
         }
-        return isValidPassword;
+        return true;
     }
 
     public boolean isValid(String password) {


### PR DESCRIPTION
# 변경점 👍
* spring-security를 이용하여 로그인 완료
-> 비밀번호 암호화 기능 
-> 안전한 정보 관리
* 로그인 시 비밀번호 및 아이디 검증 완료
-> 로그인 제약 사항 : 8자 이상, 특수문자
-> 아이디 제약 사항 : 중복 이름 X

# 리팩토링 🛠
<img width="274" alt="스크린샷 2023-03-13 오후 11 13 34" src="https://user-images.githubusercontent.com/77785750/224727513-44ed610c-7afd-4b93-9771-d3068a83bdb9.png">
: config, exception, hander 와 같은 공통적인 파일은 login파일과 같은 위치에 둠
: controller, domain, dto, repository, service 와 같은 파일은 login 관련 기능만 수행하기에 login 파일 안에 둠
 
# 스크린샷 🖼
1. 예외처리 관련 사항들
1-1. 같은 비밀번호가 아닐 경우
<img width="970" alt="스크린샷 2023-03-13 오후 10 50 51" src="https://user-images.githubusercontent.com/77785750/224727917-b1cfea34-8d52-4ce0-9e2b-d4cdb259e795.png">
1-2. 제약사항을 지키지 않았을 경우
<img width="963" alt="스크린샷 2023-03-13 오후 11 03 25" src="https://user-images.githubusercontent.com/77785750/224727919-35e148ad-d05e-41fc-95ff-4abb0e815a29.png">
1-3. 예외 정의 방식 (게시글 예외도 다음과 비슷하게 처리하면 될 듯 합니다.)
<img width="902" alt="스크린샷 2023-03-13 오후 11 05 23" src="https://user-images.githubusercontent.com/77785750/224727891-e1378b07-3584-4daa-a248-9cd01b147e08.png">

2. 회원 생성 관련
2-1. 회원 가입시 성공했을 경우
<img width="969" alt="스크린샷 2023-03-13 오후 11 04 24" src="https://user-images.githubusercontent.com/77785750/224727924-0e6b9b42-8bf6-4033-a6c1-0106f9ea4cf2.png">
: 가입한 멤버의 id제공
2-2. 비밀번호 암호화
<img width="902" alt="스크린샷 2023-03-13 오후 11 05 47" src="https://user-images.githubusercontent.com/77785750/224727901-7950c3d8-cd12-4866-bb7c-6fd3b7ae6f94.png">
2-3. 비밀번호 암호화 하여 DB 저장시 보이는 모습
<img width="884" alt="스크린샷 2023-03-13 오후 11 04 32" src="https://user-images.githubusercontent.com/77785750/224728451-df43743c-2d7e-4183-9fe4-437e4327f7ce.png">

 
# 비고 ✏
spring-security를 처음 해봐서 엉성한 부분이 있을 수도 있습니다..! 추후 로그인, 로그아웃, 회원탈퇴 기능 구현하면서 에러 발생시 수정해보겠습니다.
 
 <br>
