### PR TITLE
post & comment crud 및 외래키 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	//security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/apptive/backend/login/domain/Member.java
+++ b/src/main/java/apptive/backend/login/domain/Member.java
@@ -2,13 +2,16 @@ package apptive.backend.login.domain;
 
 import apptive.backend.config.StringListConverter;
 import apptive.backend.login.dto.request.MemberRequestDto;
+import apptive.backend.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -35,6 +38,10 @@ public class Member implements Serializable {
     @Convert(converter = StringListConverter.class)
     @Column(nullable = false)
     private List<String> diseaseList;
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+    @ToString.Exclude
+    private List<Post> postList = new ArrayList<>();
 
     //<------------Builder------------>
     @Builder

--- a/src/main/java/apptive/backend/post/controller/CommentController.java
+++ b/src/main/java/apptive/backend/post/controller/CommentController.java
@@ -1,0 +1,58 @@
+package apptive.backend.post.controller;
+
+import apptive.backend.post.dto.CommentDto;
+import apptive.backend.post.dto.CommentResponseDto;
+import apptive.backend.post.service.CommentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/comment")
+public class CommentController {
+    private final CommentService commentService;
+
+    @Autowired
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @PostMapping("/comment")
+    public ResponseEntity<CommentResponseDto> createComment(Long postId ,@RequestBody CommentDto commentDto) {
+        CommentResponseDto commentResponseDto = commentService.saveComment(postId, commentDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(commentResponseDto);
+    }
+
+    @GetMapping("/comment")
+    public ResponseEntity<CommentResponseDto> getComment(Long id) {
+        CommentResponseDto commentResponseDto = commentService.getComment(id);
+
+        return ResponseEntity.status(HttpStatus.OK).body(commentResponseDto);
+    }
+
+    @GetMapping("/comments")
+    public ResponseEntity<List<CommentResponseDto>> getComments(Long postId) {
+        List<CommentResponseDto> commentResponseDto = commentService.getComments(postId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(commentResponseDto);
+    }
+
+    @PutMapping("/comment")
+    public ResponseEntity<CommentResponseDto> changeComment(Long id, @RequestBody CommentDto commentDto) throws Exception{
+        CommentResponseDto commentResponseDto = commentService.changeComment(id, commentDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(commentResponseDto);
+    }
+
+    @DeleteMapping("/comment")
+    public ResponseEntity<String> deleteComment(Long id) throws Exception{
+        commentService.deleteComment(id);
+
+        return ResponseEntity.status(HttpStatus.OK).body("정상적으로 삭제되었습니다.");
+    }
+
+}

--- a/src/main/java/apptive/backend/post/controller/PostController.java
+++ b/src/main/java/apptive/backend/post/controller/PostController.java
@@ -1,14 +1,52 @@
 package apptive.backend.post.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import apptive.backend.post.dto.PostDto;
+import apptive.backend.post.dto.PostResponseDto;
+import apptive.backend.post.entity.Post;
+import apptive.backend.post.service.PostService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/post")
 public class PostController {
-    @GetMapping("/getOne")
-    public String getOne() {
-        return "hi";
+    private final PostService postService;
+
+    @Autowired
+    public PostController(PostService postService) {
+        this.postService = postService;
     }
+
+    @PostMapping("/post")
+    public ResponseEntity<PostResponseDto> createPost(@RequestBody PostDto postDto) {
+        PostResponseDto postResponseDto = postService.savePost(postDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(postResponseDto);
+
+    }
+
+    @GetMapping("/post")
+    public ResponseEntity<PostResponseDto> getPost(Long id) {
+        PostResponseDto postResponseDto = postService.getPost(id);
+
+        return ResponseEntity.status(HttpStatus.OK).body(postResponseDto);
+    }
+
+    @PutMapping("/post")
+    public ResponseEntity<PostResponseDto> changePost(Long id, @RequestBody PostDto postDto) throws Exception {
+        PostResponseDto postResponseDto = postService.changePost(id, postDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(postResponseDto);
+    }
+
+    @DeleteMapping("/post")
+    public ResponseEntity<String> deletePost(Long id) throws Exception {
+        postService.deletePost(id);
+
+        return ResponseEntity.status(HttpStatus.OK).body("정상적으로 삭제되었습니다.");
+    }
+
+
 }

--- a/src/main/java/apptive/backend/post/dao/CommentDao.java
+++ b/src/main/java/apptive/backend/post/dao/CommentDao.java
@@ -1,0 +1,18 @@
+package apptive.backend.post.dao;
+
+import apptive.backend.post.dto.CommentDto;
+import apptive.backend.post.entity.Comment;
+
+import java.util.List;
+
+public interface CommentDao {
+    Comment insertComment(Long postId, Comment comment);
+
+    Comment selectComment(Long id);
+
+    List<Comment> selectComments(Long postId);
+
+    Comment updateComment(Long id, CommentDto commentDto) throws Exception;
+
+    void deleteComment(Long id) throws Exception;
+}

--- a/src/main/java/apptive/backend/post/dao/Impl/CommentDaoImpl.java
+++ b/src/main/java/apptive/backend/post/dao/Impl/CommentDaoImpl.java
@@ -1,0 +1,79 @@
+package apptive.backend.post.dao.Impl;
+
+import apptive.backend.post.dao.CommentDao;
+import apptive.backend.post.dto.CommentDto;
+import apptive.backend.post.entity.Comment;
+import apptive.backend.post.entity.Post;
+import apptive.backend.post.repository.CommentRepository;
+import apptive.backend.post.repository.PostRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class CommentDaoImpl implements CommentDao {
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    @Autowired
+    public CommentDaoImpl(PostRepository postRepository, CommentRepository commentRepository) {
+        this.postRepository = postRepository;
+        this.commentRepository = commentRepository;
+    }
+
+    @Override
+    public Comment insertComment(Long postId, Comment comment) {
+        Post selectedPost = postRepository.getById(postId);
+        comment.setPost(selectedPost);
+        Comment savedComment = commentRepository.save(comment);
+
+        return savedComment;
+    }
+
+    @Override
+    public Comment selectComment(Long id) {
+        Comment selectedComment = commentRepository.getById(id);
+
+        return selectedComment;
+    }
+
+    @Override
+    public List<Comment> selectComments(Long postId) {
+        List<Comment> selectedComments = postRepository.findById(postId).get().getCommentList();
+
+        return selectedComments;
+    }
+
+    @Override
+    public Comment updateComment(Long id, CommentDto commentDto) throws Exception{
+        Optional<Comment> selectedComment = commentRepository.findById(id);
+
+        Comment updatedComment;
+        if(selectedComment.isPresent()) {
+            Comment comment = selectedComment.get();
+            comment.setCommentContent(commentDto.getCommentContent());
+            comment.setUpdatedAt(LocalDateTime.now());
+            updatedComment = commentRepository.save(comment);
+        } else {
+            throw new Exception();
+        }
+
+        return updatedComment;
+    }
+
+    @Override
+    public void deleteComment(Long id) throws Exception{
+        Optional<Comment> selectedComment = commentRepository.findById(id);
+
+        if(selectedComment.isPresent()) {
+            Comment  comment = selectedComment.get();
+            commentRepository.delete(comment);
+        } else {
+            throw new Exception();
+        }
+
+    }
+}

--- a/src/main/java/apptive/backend/post/dao/Impl/PostDAOImpl.java
+++ b/src/main/java/apptive/backend/post/dao/Impl/PostDAOImpl.java
@@ -1,4 +1,0 @@
-package apptive.backend.post.dao.Impl;
-
-public class PostDAOImpl {
-}

--- a/src/main/java/apptive/backend/post/dao/Impl/PostDaoImpl.java
+++ b/src/main/java/apptive/backend/post/dao/Impl/PostDaoImpl.java
@@ -1,0 +1,68 @@
+package apptive.backend.post.dao.Impl;
+
+import apptive.backend.post.dao.PostDao;
+import apptive.backend.post.dto.PostDto;
+import apptive.backend.post.entity.Post;
+import apptive.backend.post.repository.PostRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cglib.core.Local;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+// bean for DI
+@Component
+public class PostDaoImpl implements PostDao {
+    private final PostRepository postRepository;
+
+    @Autowired
+    public PostDaoImpl(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    @Override
+    public Post insertPost(Post post) {
+        Post savedProduct = postRepository.save(post);
+
+        return savedProduct;
+    }
+
+    @Override
+    public Post selectPost(Long id) {
+        Post selectedPost = postRepository.getById(id);
+
+        return selectedPost;
+    }
+
+    @Override
+    public Post updatePost(Long id, PostDto postDto) throws Exception {
+        Optional<Post> selectedPost = postRepository.findById(id);
+
+        Post updatedPost;
+        if(selectedPost.isPresent()) {
+            Post post = selectedPost.get(); // already exist data = fixed id = update
+            post.setPostTitle(postDto.getPostTitle());
+            post.setPostContent(postDto.getPostContent());
+            post.setPostPhoto(postDto.getPostPhoto());
+            post.setUpdatedAt(LocalDateTime.now());
+            updatedPost = postRepository.save(post);
+        } else {
+            throw new Exception();
+        }
+
+        return updatedPost;
+    }
+
+    @Override
+    public void deletePost(Long id) throws Exception {
+        Optional<Post> selectedPost = postRepository.findById(id);
+
+        if(selectedPost.isPresent()) {
+            Post post = selectedPost.get();
+            postRepository.delete(post);
+        } else{
+            throw new Exception();
+        }
+    }
+}

--- a/src/main/java/apptive/backend/post/dao/PostDAO.java
+++ b/src/main/java/apptive/backend/post/dao/PostDAO.java
@@ -1,4 +1,0 @@
-package apptive.backend.post.dao;
-
-public interface PostDAO {
-}

--- a/src/main/java/apptive/backend/post/dao/PostDao.java
+++ b/src/main/java/apptive/backend/post/dao/PostDao.java
@@ -1,0 +1,15 @@
+package apptive.backend.post.dao;
+
+import apptive.backend.post.dto.PostDto;
+import apptive.backend.post.entity.Post;
+
+public interface PostDao {
+    Post insertPost(Post post);
+
+    Post selectPost(Long id);
+
+    Post updatePost(Long id, PostDto postDto) throws Exception;
+
+    void deletePost(Long id) throws Exception;
+
+}

--- a/src/main/java/apptive/backend/post/dto/CommentDto.java
+++ b/src/main/java/apptive/backend/post/dto/CommentDto.java
@@ -1,0 +1,8 @@
+package apptive.backend.post.dto;
+
+import lombok.Data;
+
+@Data
+public class CommentDto {
+    private String commentContent;
+}

--- a/src/main/java/apptive/backend/post/dto/CommentResponseDto.java
+++ b/src/main/java/apptive/backend/post/dto/CommentResponseDto.java
@@ -1,0 +1,11 @@
+package apptive.backend.post.dto;
+
+import lombok.Data;
+
+@Data
+public class CommentResponseDto {
+    private Long commentId;
+
+    private String commentContent;
+
+}

--- a/src/main/java/apptive/backend/post/dto/PostDTO.java
+++ b/src/main/java/apptive/backend/post/dto/PostDTO.java
@@ -1,4 +1,0 @@
-package apptive.backend.post.dto;
-
-public interface PostDTO {
-}

--- a/src/main/java/apptive/backend/post/dto/PostDto.java
+++ b/src/main/java/apptive/backend/post/dto/PostDto.java
@@ -1,0 +1,12 @@
+package apptive.backend.post.dto;
+
+import lombok.Data;
+
+@Data
+public class PostDto {
+    private String postTitle;
+
+    private String postContent;
+
+    private String postPhoto;
+}

--- a/src/main/java/apptive/backend/post/dto/PostResponseDto.java
+++ b/src/main/java/apptive/backend/post/dto/PostResponseDto.java
@@ -1,0 +1,14 @@
+package apptive.backend.post.dto;
+
+import lombok.Data;
+
+@Data
+public class PostResponseDto {
+    private Long postId;
+
+    private String postTitle;
+
+    private String postContent;
+
+    private String postPhoto;
+}

--- a/src/main/java/apptive/backend/post/entity/Comment.java
+++ b/src/main/java/apptive/backend/post/entity/Comment.java
@@ -1,0 +1,28 @@
+package apptive.backend.post.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentId;
+
+    private String commentContent;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "post_postId")
+    @ToString.Exclude
+    private Post post;
+}

--- a/src/main/java/apptive/backend/post/entity/Post.java
+++ b/src/main/java/apptive/backend/post/entity/Post.java
@@ -1,4 +1,41 @@
 package apptive.backend.post.entity;
 
+import apptive.backend.login.domain.Member;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Data
+@NoArgsConstructor
 public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postId;
+
+    private String postTitle;
+
+    private String postContent;
+
+    private String postPhoto;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    //member N:1
+    @ManyToOne
+    @JoinColumn(name = "member_memberId")
+    @ToString.Exclude
+    private Member member;
+
+    //comment 1:N, post별 모든 comment조회
+    @OneToMany(mappedBy = "post", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+    @ToString.Exclude
+    private List<Comment> commentList = new ArrayList<>();
 }

--- a/src/main/java/apptive/backend/post/repository/CommentRepository.java
+++ b/src/main/java/apptive/backend/post/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package apptive.backend.post.repository;
+
+import apptive.backend.post.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/apptive/backend/post/repository/PostRepository.java
+++ b/src/main/java/apptive/backend/post/repository/PostRepository.java
@@ -1,4 +1,7 @@
 package apptive.backend.post.repository;
 
-public interface PostRepository {
+import apptive.backend.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
 }

--- a/src/main/java/apptive/backend/post/repository/service/Impl/PostServiceImpl.java
+++ b/src/main/java/apptive/backend/post/repository/service/Impl/PostServiceImpl.java
@@ -1,4 +1,0 @@
-package apptive.backend.post.repository.service.Impl;
-
-public class PostServiceImpl {
-}

--- a/src/main/java/apptive/backend/post/repository/service/PostService.java
+++ b/src/main/java/apptive/backend/post/repository/service/PostService.java
@@ -1,4 +1,0 @@
-package apptive.backend.post.repository.service;
-
-public interface PostService {
-}

--- a/src/main/java/apptive/backend/post/service/CommentService.java
+++ b/src/main/java/apptive/backend/post/service/CommentService.java
@@ -1,0 +1,23 @@
+package apptive.backend.post.service;
+
+import apptive.backend.post.dto.CommentDto;
+import apptive.backend.post.dto.CommentResponseDto;
+
+import java.util.List;
+
+public interface CommentService {
+    //comment 생성, postId를 주어 comment entity필드에 현재 post를 넘겨주면 post entity에 List<comment>로 넘어감.
+    CommentResponseDto saveComment(Long postId, CommentDto commentDto);
+
+    //comment 1개 조회
+    CommentResponseDto getComment(Long id);
+
+    //post 모든 댓글 조회
+    List<CommentResponseDto> getComments(Long postId);
+
+    //comment 수정
+    CommentResponseDto changeComment(Long id, CommentDto commentDto) throws Exception;
+
+    //comment 삭제
+    void deleteComment(Long id) throws Exception;
+}

--- a/src/main/java/apptive/backend/post/service/Impl/CommentServiceImpl.java
+++ b/src/main/java/apptive/backend/post/service/Impl/CommentServiceImpl.java
@@ -1,0 +1,82 @@
+package apptive.backend.post.service.Impl;
+
+import apptive.backend.post.dao.CommentDao;
+import apptive.backend.post.dto.CommentDto;
+import apptive.backend.post.dto.CommentResponseDto;
+import apptive.backend.post.entity.Comment;
+import apptive.backend.post.service.CommentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class CommentServiceImpl implements CommentService {
+    private final CommentDao commentDao;
+
+    @Autowired
+    public CommentServiceImpl(CommentDao commentDao) {
+        this.commentDao = commentDao;
+    }
+
+    @Override
+    public CommentResponseDto saveComment(Long postId, CommentDto commentDto) {
+        Comment comment = new Comment();
+        comment.setCommentContent(commentDto.getCommentContent());
+        comment.setCreatedAt(LocalDateTime.now());
+        comment.setUpdatedAt(LocalDateTime.now());
+
+        Comment savedComment = commentDao.insertComment(postId, comment);
+
+        CommentResponseDto commentResponseDto = new CommentResponseDto();
+        commentResponseDto.setCommentId(savedComment.getCommentId());
+        commentResponseDto.setCommentContent(savedComment.getCommentContent());
+
+        return commentResponseDto;
+    }
+
+    @Override
+    public CommentResponseDto getComment(Long id) {
+        Comment comment = commentDao.selectComment(id);
+
+        CommentResponseDto commentResponseDto = new CommentResponseDto();
+        commentResponseDto.setCommentId(comment.getCommentId());
+        commentResponseDto.setCommentContent(comment.getCommentContent());
+
+        return commentResponseDto;
+    }
+
+    // postId로 comments조회.
+    @Override
+    public List<CommentResponseDto> getComments(Long postId) {
+        List<Comment> comments = commentDao.selectComments(postId);
+        List<CommentResponseDto> responseComments = new ArrayList<>();
+        for(Comment comment : comments) {
+            CommentResponseDto responseComment = new CommentResponseDto();
+            responseComment.setCommentId(comment.getCommentId());
+            responseComment.setCommentContent(comment.getCommentContent());
+            responseComments.add(responseComment);
+        }
+        return responseComments;
+    }
+
+    @Override
+    public CommentResponseDto changeComment(Long id, CommentDto commentDto) throws Exception {
+        Comment changedComment = commentDao.updateComment(id, commentDto);
+
+        CommentResponseDto commentResponseDto = new CommentResponseDto();
+        commentResponseDto.setCommentId(changedComment.getCommentId());
+        commentResponseDto.setCommentContent(changedComment.getCommentContent());
+
+        return commentResponseDto;
+    }
+
+    @Override
+    public void deleteComment(Long id) throws Exception {
+        commentDao.deleteComment(id);
+    }
+
+
+}

--- a/src/main/java/apptive/backend/post/service/Impl/PostServiceImpl.java
+++ b/src/main/java/apptive/backend/post/service/Impl/PostServiceImpl.java
@@ -1,0 +1,72 @@
+package apptive.backend.post.service.Impl;
+
+import apptive.backend.post.dao.PostDao;
+import apptive.backend.post.dto.PostDto;
+import apptive.backend.post.dto.PostResponseDto;
+import apptive.backend.post.entity.Post;
+import apptive.backend.post.service.PostService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class PostServiceImpl implements PostService {
+    private final PostDao postDao;
+
+    @Autowired
+    public PostServiceImpl(PostDao postDao) {
+        this.postDao = postDao;
+    }
+
+    @Override
+    public PostResponseDto savePost(PostDto postDto) {
+        Post post = new Post();
+        post.setPostTitle(postDto.getPostTitle());
+        post.setPostContent(postDto.getPostContent());
+        post.setPostPhoto(postDto.getPostPhoto());
+        post.setCreatedAt(LocalDateTime.now());
+        post.setUpdatedAt(LocalDateTime.now());
+
+        Post savedPost = postDao.insertPost(post);
+
+        PostResponseDto postResponseDto = new PostResponseDto();
+        postResponseDto.setPostId(savedPost.getPostId());
+        postResponseDto.setPostTitle(savedPost.getPostTitle());
+        postResponseDto.setPostContent(savedPost.getPostContent());
+        postResponseDto.setPostPhoto(savedPost.getPostPhoto());
+
+        return postResponseDto;
+    }
+
+    @Override
+    public PostResponseDto getPost(Long id) {
+        Post post = postDao.selectPost(id);
+
+        PostResponseDto postResponseDto = new PostResponseDto();
+        postResponseDto.setPostId(post.getPostId());
+        postResponseDto.setPostTitle(post.getPostTitle());
+        postResponseDto.setPostContent(post.getPostContent());
+        postResponseDto.setPostPhoto(post.getPostPhoto());
+
+        return postResponseDto;
+    }
+
+    @Override
+    public PostResponseDto changePost(Long id, PostDto postDto) throws Exception {
+        Post changedPost = postDao.updatePost(id, postDto);
+
+        PostResponseDto postResponseDto = new PostResponseDto();
+        postResponseDto.setPostId(changedPost.getPostId());
+        postResponseDto.setPostTitle(changedPost.getPostTitle());
+        postResponseDto.setPostContent(changedPost.getPostContent());
+        postResponseDto.setPostPhoto(changedPost.getPostPhoto());
+
+        return postResponseDto;
+    }
+
+    @Override
+    public void deletePost(Long id) throws Exception{
+        postDao.deletePost(id);
+    }
+}

--- a/src/main/java/apptive/backend/post/service/PostService.java
+++ b/src/main/java/apptive/backend/post/service/PostService.java
@@ -1,0 +1,14 @@
+package apptive.backend.post.service;
+
+import apptive.backend.post.dto.PostDto;
+import apptive.backend.post.dto.PostResponseDto;
+
+public interface PostService {
+    PostResponseDto savePost(PostDto postDto);
+
+    PostResponseDto getPost(Long id);
+
+    PostResponseDto changePost(Long id, PostDto postDto) throws Exception;
+
+    void deletePost(Long id) throws Exception;
+}


### PR DESCRIPTION
추가로 각 post에 대한 모든 comments 조회 구현

# 변경점 👍
 member entity 외래키 설정
 
# 스크린샷 🖼 
![스크린샷(142)_LI](https://user-images.githubusercontent.com/78483046/225342204-b3b4dab6-7151-4fe5-bcda-dac12c2a484c.jpg)
외래키 설정으로 인해 post_2를 삭제하자 그에 연결된 모든 comments들도 cascade로 삭제되는 모습.
그 이외의 기본적인 CRUD잘 동작함. 예외처리는 아직.
