### PR TITLE
로그인 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 	//security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 
 	//token
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'

--- a/src/main/java/apptive/backend/config/MemberConfig.java
+++ b/src/main/java/apptive/backend/config/MemberConfig.java
@@ -35,42 +35,8 @@ public class MemberConfig {
         return new BCryptPasswordEncoder();
     }
 
-    //특정 경로의 파일 무시
-
-    //HTTP Basic : 모든 엔드포인트 보호
-    /*@Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-
-        http
-                .authorizeHttpRequests((authz) -> authz
-                        .anyRequest().authenticated())
-                .httpBasic(Customizer.withDefaults());
-
-        return http.build();
-    }*/
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers("/member/**", "/login");
-    }
-
     @Bean
     protected SecurityFilterChain configure(HttpSecurity httpSecurity) throws Exception {
-
-        /*httpSecurity
-                .httpBasic().disable()
-                .csrf().disable()
-                .cors().and()
-                .headers().frameOptions().disable().and()
-                .authorizeHttpRequests()
-                .requestMatchers("/login", "/member/**").permitAll()
-                .requestMatchers("/post/**").hasAuthority("USER")
-                .anyRequest().authenticated();
-
-        httpSecurity
-                .sessionManagement()
-                .maximumSessions(1)
-                .maxSessionsPreventsLogin(true);*/
 
         httpSecurity
                 .csrf().disable().headers().frameOptions().disable()
@@ -78,7 +44,7 @@ public class MemberConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeHttpRequests().requestMatchers("/member/**", "/login").permitAll()
-                .anyRequest().authenticated()
+                .anyRequest().hasRole("USER") //다른 url로 접근 시 USER 권한이 있어야 함
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/apptive/backend/login/controller/LoginController.java
+++ b/src/main/java/apptive/backend/login/controller/LoginController.java
@@ -1,13 +1,15 @@
 package apptive.backend.login.controller;
 
 import apptive.backend.login.dto.request.LoginRequestDto;
-import apptive.backend.login.service.LoginService;
 import apptive.backend.login.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
@@ -21,5 +23,4 @@ public class LoginController {
     public ResponseEntity login(@RequestBody LoginRequestDto loginRequestDto) {
         return new ResponseEntity(memberService.login(loginRequestDto), HttpStatus.OK);
     }
-
 }

--- a/src/main/java/apptive/backend/login/controller/TestController.java
+++ b/src/main/java/apptive/backend/login/controller/TestController.java
@@ -1,0 +1,18 @@
+package apptive.backend.login.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class TestController {
+
+    @GetMapping("/test")
+    public String test() {
+
+        return "<h1>테스트 성공</h1>";
+    }
+}

--- a/src/main/java/apptive/backend/login/domain/Member.java
+++ b/src/main/java/apptive/backend/login/domain/Member.java
@@ -2,12 +2,10 @@ package apptive.backend.login.domain;
 
 import apptive.backend.config.StringListConverter;
 import apptive.backend.login.dto.request.MemberRequestDto;
-import apptive.backend.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -49,9 +47,9 @@ public class Member implements Serializable, UserDetails {
     @Column(nullable = false)
     private List<String> diseaseList;
 
-    @OneToMany(mappedBy = "member", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+    /*@OneToMany(mappedBy = "member", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
     @ToString.Exclude
-    private List<Post> postList = new ArrayList<>();
+    private List<Post> postList = new ArrayList<>();*/
 
     //<------------Builder------------>
     @Builder

--- a/src/main/java/apptive/backend/login/jwt/JwtTokenProvider.java
+++ b/src/main/java/apptive/backend/login/jwt/JwtTokenProvider.java
@@ -21,7 +21,7 @@ import java.util.List;
 @Component
 public class JwtTokenProvider {
 
-    private String secretKey = "webfirewood";
+    private String secretKey = "mysecretkey";
     private long tokenValidTime = 30*60*1000L; //토큰 유효시간 30분
     private final UserDetailsService userDetailsService;
 
@@ -45,7 +45,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    //인증 정보 조회
+    // 인증 정보 조회
     public Authentication getAuthentication(String token) {
 
         UserDetails userDetails = userDetailsService.loadUserByUsername(getUserPK(token));
@@ -68,7 +68,8 @@ public class JwtTokenProvider {
     }
 
     // Request의 Header 에서 token 값 가져오기
+    // 헤더에서 "AccessToken"이란 이름으로 제공 가능
     public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("X-AUTH-TOKEN");
+        return request.getHeader("AccessToken");
     }
 }

--- a/src/main/java/apptive/backend/login/service/LoginService.java
+++ b/src/main/java/apptive/backend/login/service/LoginService.java
@@ -1,19 +1,12 @@
 package apptive.backend.login.service;
 
-import apptive.backend.exception.ExceptionEnum;
-import apptive.backend.exception.login.LoginException;
-import apptive.backend.exception.login.MemberNotExistException;
-import apptive.backend.login.domain.Member;
 import apptive.backend.login.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Slf4j
 @Service


### PR DESCRIPTION
# 이슈
* #8 

# 변경점 👍
## 로그인 및 회원가입 기능 완성
- JWT + Spring Security를 이용하여 로그인 기능 구현
- Access Token을 이용하여 사용자 정보를 얻을 수 있고, "/member/\**", "/login/**" (회원가입 및 로그인)은 ROLE이 없어도 접근 가능함
- Token의 유효 기간은 30분으로 설정 해 둠. 30분이 지나면 로그인 해제
 
# 스크린샷 🖼
1. 로그인 성공 및 토큰 전달 
1.1. 테스트용 페이지
<img width="800" src="https://user-images.githubusercontent.com/77785750/236666010-d2ae5de7-9ff6-4789-bdb4-f430583f4f06.png">
1.2. 헤더에 토큰 넣어 전달 및 성공 시 보이는 화면
<img width="800" src="https://user-images.githubusercontent.com/77785750/236666031-33eacfe7-d2d2-46bc-8530-0c518c5be234.png">
1.3. ROLE 없어도 접근 가능한 url 및 필요한 ROLE
(현재는 /login/** 로 수정됨)
<img width="800" src="https://user-images.githubusercontent.com/77785750/236666018-abb36fbb-7040-4378-b525-1328e57c0d0e.png">

- antMatchers() : 해당 URL로 요청 시 설정을 해줌
- authenticated() : andMatchers에 속해있는 URL로 요청이 오면 인증이 필요하다고 설정
- hasRole() : andMatchers에 속해있는 URL로 요청이 들어오면 권한을 확인
- addFilterBefore() : 필터를 등록한다. 스프링 시큐리티 필터링에 등록해주어야 하기 때문에, 여기에 등록해주어야 함. 파라미터는 2가지가 들어감. 왼쪽은 커스텀한 필터링이 들어감. 오른쪽에 등록한 필터전에 커스텀필터링이 수행.
- http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) : 세션을 사용하지 않는다고 설정 함.

2. 현재 h2 사용시 POST 관련 테이블이 만들어지지 않는다고 하여 member 테이블에서 삭제 후 진행
<img width="800" src="https://user-images.githubusercontent.com/77785750/236666015-45a238fc-7657-487a-9c6b-8727ed853f18.png">

 
# 비고 ✏
 - 30분 이후에도 접속하고 싶을 시 연장을 할지 혹은 재로그인을 할 지 논의해봐야함 (학교 홈페이지 사용 예시)
 <img width="800" src="https://user-images.githubusercontent.com/77785750/236666027-eb31db5b-7ae6-4b41-b367-22782e38bc8f.png">
 <br>