### PR TITLE
logout 기능 완성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 	//DB
 	implementation 'com.h2database:h2'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	//runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
 	//lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -39,6 +39,9 @@ dependencies {
 
 	//token
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.0.4'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/src/main/java/apptive/backend/config/MemberConfig.java
+++ b/src/main/java/apptive/backend/config/MemberConfig.java
@@ -4,15 +4,14 @@ import apptive.backend.handler.login.CustomLoginFailureHandler;
 import apptive.backend.handler.login.CustomLoginSuccessHandler;
 import apptive.backend.login.jwt.JwtAuthenticationFilter;
 import apptive.backend.login.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -43,10 +42,20 @@ public class MemberConfig {
                 .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .authorizeHttpRequests().requestMatchers("/member/**", "/login").permitAll()
+                .authorizeHttpRequests().requestMatchers("/member/**", "/login/**", "/").permitAll()
                 .anyRequest().hasRole("USER") //다른 url로 접근 시 USER 권한이 있어야 함
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .logout()
+                .logoutUrl("/logout")
+                .logoutSuccessUrl("/") // 로그아웃 처리 URL
+                .deleteCookies("JSESSIONID")
+                .logoutSuccessHandler(((request, response, authentication) -> response.sendRedirect("/")))
+                .addLogoutHandler((request, response, authentication) -> {
+                    //System.out.println("logout Success!");
+                    HttpSession session = request.getSession();
+                    session.invalidate();
+                });
 
         return httpSecurity.build();
     }

--- a/src/main/java/apptive/backend/config/RedisRepositoryConfig.java
+++ b/src/main/java/apptive/backend/config/RedisRepositoryConfig.java
@@ -1,0 +1,40 @@
+package apptive.backend.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisRepositoryConfig {
+
+    private final RedisProperties redisProperties;
+
+    // lettuce
+    // RedisConnectionFactory 인터페이스를 통해 LettuceConnectionFactory 를 생성하여 반환함.
+    // RedisProperties 로 yaml 에 저장한 host, port 를 가지고 와서 연결함.
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    // setKeySerializer, setValueSerializer 설정으로 redis-cli를 통해
+    // 직접 데이터를 보기 가능
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/apptive/backend/login/controller/LoginController.java
+++ b/src/main/java/apptive/backend/login/controller/LoginController.java
@@ -1,26 +1,24 @@
 package apptive.backend.login.controller;
 
 import apptive.backend.login.dto.request.LoginRequestDto;
-import apptive.backend.login.service.MemberService;
+import apptive.backend.login.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/login")
 public class LoginController {
 
-    private final MemberService memberService;
+    private final LoginService loginService;
 
-    @PostMapping("")
-    public ResponseEntity login(@RequestBody LoginRequestDto loginRequestDto) {
-        return new ResponseEntity(memberService.login(loginRequestDto), HttpStatus.OK);
+    @PostMapping("/login")
+    public ResponseEntity login(@RequestBody LoginRequestDto.LoginDto loginRequestDto) {
+        return new ResponseEntity(loginService.login(loginRequestDto), HttpStatus.OK);
     }
 }

--- a/src/main/java/apptive/backend/login/dto/request/LoginRequestDto.java
+++ b/src/main/java/apptive/backend/login/dto/request/LoginRequestDto.java
@@ -1,14 +1,30 @@
 package apptive.backend.login.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Getter
 public class LoginRequestDto {
 
-    @NotNull
-    private String memberNickname;
+    @Getter
+    public static class LoginDto {
+        @NotNull
+        private String memberNickname;
 
-    @NotNull
-    private String password;
+        @NotNull
+        private String password;
+    }
+
+    @Getter
+    public static class TokenDto {
+
+        private String accessToken;
+        private String refreshToken;
+
+        public TokenDto(String accessToken, String refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+    }
 }

--- a/src/main/java/apptive/backend/login/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/apptive/backend/login/jwt/JwtAuthenticationFilter.java
@@ -22,7 +22,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         //헤더에서 토큰 받아오기
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
 
-        //토큰이 유효하다면
+        // 유효한 토큰인지 확인 -> validation 진행
         if (token != null && jwtTokenProvider.validateToken(token)) {
 
             //토큰으로부터 유저 정보를 받아

--- a/src/main/java/apptive/backend/login/service/AuthService.java
+++ b/src/main/java/apptive/backend/login/service/AuthService.java
@@ -1,0 +1,24 @@
+package apptive.backend.login.service;
+
+import apptive.backend.login.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    // <-------------------- ? -------------------->
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return memberRepository.findByMemberNickname(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/apptive/backend/login/service/LoginService.java
+++ b/src/main/java/apptive/backend/login/service/LoginService.java
@@ -1,24 +1,40 @@
 package apptive.backend.login.service;
 
+import apptive.backend.exception.ExceptionEnum;
+import apptive.backend.exception.login.LoginException;
+import apptive.backend.exception.login.MemberNotExistException;
+import apptive.backend.login.domain.Member;
+import apptive.backend.login.dto.request.LoginRequestDto;
+import apptive.backend.login.jwt.JwtTokenProvider;
 import apptive.backend.login.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
-public class LoginService implements UserDetailsService {
+@Transactional(readOnly = true)
+public class LoginService {
 
+    private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    // <-------------------- ? -------------------->
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberRepository.findByMemberNickname(username)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+    //<------------ 로그인 ------------>
+    @Transactional
+    public String login(LoginRequestDto.LoginDto loginDto) {
+
+        // 로그인 시 member 찾을 수 있으면 정보 가져옴
+        Member member = memberRepository.findByMemberNickname(loginDto.getMemberNickname())
+                .orElseThrow(() -> new MemberNotExistException(ExceptionEnum.MEMBER_NOT_EXIST_EXCEPTION));
+
+        // 패스워드 불일치 하면 에러 발생
+        if (!passwordEncoder.matches(loginDto.getPassword(), member.getPwd())) {
+            throw new LoginException(ExceptionEnum.WRONG_PWD_EXCEPTION);
+        }
+
+        // Access Token, Refresh Token 발급
+        return jwtTokenProvider.createToken(member.getMemberNickname(), member.getRoles());
     }
 }

--- a/src/main/java/apptive/backend/login/service/MemberService.java
+++ b/src/main/java/apptive/backend/login/service/MemberService.java
@@ -1,17 +1,13 @@
 package apptive.backend.login.service;
 
 import apptive.backend.exception.ExceptionEnum;
-import apptive.backend.exception.login.LoginException;
 import apptive.backend.exception.login.MemberNotExistException;
 import apptive.backend.exception.login.PwdConditionException;
 import apptive.backend.exception.login.SameNickNameException;
 import apptive.backend.login.domain.Member;
-import apptive.backend.login.dto.request.LoginRequestDto;
 import apptive.backend.login.dto.request.MemberRequestDto;
-import apptive.backend.login.jwt.JwtTokenProvider;
 import apptive.backend.login.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +18,6 @@ import java.util.Optional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final PasswordEncoder passwordEncoder;
 
     //<------------ 회원가입 ------------>
     @Transactional
@@ -57,21 +51,6 @@ public class MemberService {
         //회원 존재하는지 확인
         Member member = isMemberExist(memberId);
         memberRepository.delete(member);
-    }
-
-    //<------------ 로그인 ------------>
-    @Transactional
-    public String login(LoginRequestDto loginRequestDto) {
-
-        Member member = memberRepository.findByMemberNickname(loginRequestDto.getMemberNickname())
-                .orElseThrow(() -> new MemberNotExistException(ExceptionEnum.MEMBER_NOT_EXIST_EXCEPTION));
-
-        if(!passwordEncoder.matches(loginRequestDto.getPassword(), member.getPwd())) {
-            throw  new LoginException(ExceptionEnum.WRONG_PWD_EXCEPTION);
-        }
-
-        //로그인에 성공하면 email, roles 로 토큰 생성 후 반환
-        return jwtTokenProvider.createToken(member.getMemberNickname(), member.getRoles());
     }
 
     //<------------verification method------------>

--- a/src/main/java/apptive/backend/mainpage/controller/MainPageController.java
+++ b/src/main/java/apptive/backend/mainpage/controller/MainPageController.java
@@ -1,0 +1,17 @@
+package apptive.backend.mainpage.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class MainPageController {
+
+    @GetMapping("/")
+    public String mainPage() {
+        return "Success!";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,8 @@ spring:
     hibernate:
       ddl-auto: create
     #database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
* #9 

# 변경점 👍
## 로그아웃 기능 완성
- 로그아웃 기능을 완료하였습니다. "/logout"을 가지며, Header에 AccessToken : (토큰값)을 넣어주어 POST로 전송하면 로그아웃되며 메인화면으로 전환됩니다.
 
# 스크린샷 🖼
1. 메인페이지
<img width="428" src="https://user-images.githubusercontent.com/77785750/236824719-11b2da81-4e04-480e-bb09-c56fa676d722.png">
확인 용으로 String을 리턴하도록 해 두었고, 로그아웃 시(로그인 및 회원가입 전)의 메인화면은 프론트에서만 작업해주면 될 것 같아 이렇게 만들어두었습니다.

1-1. 전송 방법
<img width="1341" src="https://user-images.githubusercontent.com/77785750/236824725-9f9b722c-a52a-4a95-86d5-b42093f11f3e.png">
POST 메소드를 이용하여 "(기본 url)/logout" 하면 메인 페이지로 이동합니다.
헤더에 AccessToken 값을 넣어주어야 합니다.

2. Config
<img width="799" src="https://user-images.githubusercontent.com/77785750/236824738-57c8ea2b-b9a8-4187-b607-e8d70d1c1bfa.png">
관련 Configuration 입니다. 쿠키 값을 삭제하고 메인 페이지로 이동하도록 설정해두었습니다.
 
# 비고 ✏
토큰의 유효 기간을 늘려둘 계획입니다.
 <br>
